### PR TITLE
Fix ArrayDestructure types in useMutation and useQuery.

### DIFF
--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -7,7 +7,7 @@ import { invariant, isString, useURLRequiredInvariant } from './utils'
 type ArrayDestructure<TData = any> = [
   TData | undefined,
   boolean,
-  Error,
+  Error | undefined,
   (variables?: object) => Promise<any>,
 ]
 interface ObjectDestructure<TData = any> extends ReqBase<TData> {

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -7,7 +7,7 @@ import { invariant, isString, useURLRequiredInvariant } from './utils'
 type ArrayDestructure<TData = any> = [
   TData | undefined,
   boolean,
-  Error,
+  Error | undefined,
   (variables?: object) => Promise<any>,
 ]
 interface ObjectDestructure<TData = any> extends ReqBase<TData> {


### PR DESCRIPTION
This PR is targeted towards the branch of this PR: https://github.com/ava/use-http/pull/334

This patch should fix the issues found by circleci:
![image](https://user-images.githubusercontent.com/19592990/127954743-9c2dd85e-7d06-4231-863c-a67dcc1ce2fb.png)
